### PR TITLE
feat: enable built-in decorators

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -6,6 +6,15 @@ lint:
     - recommended
   rules:
     no-unused-components: warning
+  decorators: 
+    info-description-override:
+      filePath: ./openapi/alternative-description.md
+    operation-description-override:
+      operationIds:
+        postPathItemWithExamples: ./openapi/paths/operation-description-example.md
+    tag-description-override:
+      tagNames:
+        Tag: ./openapi/tag-description-alternative.md
 referenceDocs:
   htmlTemplate: ./docs/index.html
   theme:
@@ -14,7 +23,7 @@ referenceDocs:
         main: "#32329f"
   generateCodeSamples:
     languages:  # Array of language config objects; indicates in which languages to generate code samples.
-      - lang: curl # Can be one of the following supported languages: "curl", "Node.js", "JavaScript".
+      - lang: curl # Can be one of the following supported languages: "curl", "Node.js", "JavaScript". "Java", "C#", "Python", "Go", "Ruby", "PHP"
       - lang: "Node.js"
       - lang: "JavaScript"
       

--- a/openapi/alternative-description.md
+++ b/openapi/alternative-description.md
@@ -1,0 +1,7 @@
+This is an **alternative** description.
+
+If we see this, the `info-description-override` decorator ran.
+
+Read about it here: https://redoc.ly/docs/cli/resources/built-in-decorators/
+
+See it in use in the `.redocly.yaml` file at the root of the repo.

--- a/openapi/paths/operation-description-example.md
+++ b/openapi/paths/operation-description-example.md
@@ -1,0 +1,1 @@
+This is an **alternative** operation description.

--- a/openapi/paths/operation-description-example.md
+++ b/openapi/paths/operation-description-example.md
@@ -1,1 +1,5 @@
 This is an **alternative** operation description.
+
+### This is an H3
+
+It is a longer description.

--- a/openapi/tag-description-alternative.md
+++ b/openapi/tag-description-alternative.md
@@ -1,0 +1,1 @@
+This is an **alternative** tag description.


### PR DESCRIPTION
This pull request is outdated. See the project readme for an updated example of using override decorators.

https://github.com/redocly-demo/decorators-demo